### PR TITLE
Adds direct hotkeys for each built-in action

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Quill runs quietly in your system tray, ready to help whenever you need it. Whet
 - **Windows DPAPI Encryption** - Your API key is securely encrypted and bound to your Windows account
 - **Global Hotkey** - Works in any application
 - **Quick Repeat** - Instantly repeat last action with a single hotkey
+- **Direct Action Hotkeys** - Run Grammar/Rewrite/Summarize/Translate instantly
 - **System Tray** - Runs quietly in the background
 - **Dark Theme** - Easy on the eyes
 
@@ -81,6 +82,10 @@ On first launch, you'll see the onboarding window:
 
 - `Ctrl+Space` - Open Quill popup (customizable)
 - `Ctrl+Shift+Space` - Quick Repeat: repeat last action without popup (customizable)
+- `Ctrl+Shift+G` - Grammar Check direct action (default)
+- `Ctrl+Shift+R` - Rewrite direct action (default)
+- `Ctrl+Shift+S` - Summarize direct action (default)
+- `Ctrl+Shift+T` - Translate direct action (default)
 - `Ctrl+Enter` - Send custom instruction
 - `Esc` - Close popup
 
@@ -142,6 +147,7 @@ Access via system tray → Settings:
 - **Hotkey Tab**
   - Main Hotkey - Opens popup for action selection
   - Quick Repeat - Repeats last action without popup (optional)
+  - Direct Action Hotkeys - Run selected action directly (optional)
 
 - **Prompts Tab**
   - Edit prompt names and temperatures

--- a/app/application.py
+++ b/app/application.py
@@ -76,6 +76,7 @@ class QuillApp(QApplication):
         self._last_prompt_key: str = ""
         self._last_instruction: str = ""
         self._quick_mode: bool = False  # 빠른 실행 모드 플래그
+        self._pending_direct_prompt_key: str = ""  # Pending prompt for direct action hotkey
         self._extraction_in_progress: bool = False  # 텍스트 추출 진행 중 플래그
 
         # AI 요청 동기화
@@ -114,6 +115,7 @@ class QuillApp(QApplication):
         # Hotkey Manager
         self.hotkey_manager.hotkey_pressed.connect(self._on_hotkey_pressed)
         self.hotkey_manager.quick_hotkey_pressed.connect(self._on_quick_hotkey_pressed)
+        self.hotkey_manager.action_hotkey_pressed.connect(self._on_action_hotkey_pressed)
 
         # Text Processor
         self.text_processor.text_extracted.connect(self._on_text_extracted)
@@ -195,8 +197,12 @@ class QuillApp(QApplication):
             # 핫키 시작
             hotkey = self.config_manager.get("hotkey.key", "<ctrl>+<space>")
             quick_hotkey = self.config_manager.get("hotkey.quick_key", "")
-            self.hotkey_manager.start(hotkey, quick_hotkey)
-            logger.info(f"Hotkey started: main={hotkey}, quick={quick_hotkey or 'disabled'}")
+            action_hotkeys = self._get_action_hotkeys_config()
+            self.hotkey_manager.start(hotkey, quick_hotkey, action_hotkeys)
+            logger.info(
+                f"Hotkey started: main={hotkey}, quick={quick_hotkey or 'disabled'}, "
+                f"action_keys={action_hotkeys}"
+            )
 
             # 트레이 아이콘 생성
             self.tray_manager.create_tray_icon()
@@ -215,6 +221,26 @@ class QuillApp(QApplication):
                 f"Failed to start application: {e}\n\nPlease check your configuration."
             )
             self.quit()
+
+    def _get_action_hotkeys_config(self) -> dict:
+        """Read and normalize direct action hotkeys from config."""
+        defaults = {
+            "grammar_check": "<ctrl>+<shift>+<g>",
+            "rewrite": "<ctrl>+<shift>+<r>",
+            "summarize": "<ctrl>+<shift>+<s>",
+            "translate": "<ctrl>+<shift>+<t>"
+        }
+
+        action_hotkeys = self.config_manager.get("hotkey.action_keys", {})
+        if not isinstance(action_hotkeys, dict):
+            return defaults
+
+        normalized = defaults.copy()
+        for key in normalized.keys():
+            value = action_hotkeys.get(key, "")
+            if isinstance(value, str):
+                normalized[key] = value
+        return normalized
 
     @Slot(int, int)
     def _on_hotkey_pressed(self, x: int, y: int):
@@ -237,6 +263,7 @@ class QuillApp(QApplication):
 
         # 일반 모드로 텍스트 추출
         self._quick_mode = False
+        self._pending_direct_prompt_key = ""
         self._extraction_in_progress = True
         self.text_processor.extract_selected_text()
 
@@ -260,6 +287,7 @@ class QuillApp(QApplication):
         if not self._last_prompt_key:
             logger.debug("No previous action, falling back to normal popup")
             self._quick_mode = False
+            self._pending_direct_prompt_key = ""
             self._extraction_in_progress = True
             self.text_processor.extract_selected_text()
             return
@@ -278,6 +306,7 @@ class QuillApp(QApplication):
 
         # 빠른 실행 모드 설정
         self._quick_mode = True
+        self._pending_direct_prompt_key = ""
 
         # 이미 추출 진행 중이면 해당 추출 결과를 quick mode로 사용
         if self._extraction_in_progress:
@@ -289,6 +318,37 @@ class QuillApp(QApplication):
         self.text_processor.extract_selected_text()
 
         # 참고: 텍스트가 추출되면 _on_text_extracted()가 호출됨
+
+    @Slot(str, int, int)
+    def _on_action_hotkey_pressed(self, prompt_key: str, x: int, y: int):
+        """
+        Called when a direct action hotkey is pressed.
+
+        Args:
+            prompt_key: Prompt key to execute
+            x: Mouse X position
+            y: Mouse Y position
+        """
+        if self._ai_request_in_progress:
+            logger.debug("AI request in progress, ignoring action hotkey")
+            return
+
+        if not self.prompt_manager.get_prompt_info(prompt_key):
+            logger.warning(f"Unknown prompt for action hotkey: {prompt_key}")
+            return
+
+        logger.debug(f"Action hotkey pressed at ({x}, {y}), prompt={prompt_key}")
+
+        self._quick_mode = False
+        self._pending_direct_prompt_key = prompt_key
+
+        # If extraction is already running, use that result for direct mode
+        if self._extraction_in_progress:
+            logger.debug("Extraction already in progress, will use its result for direct action")
+            return
+
+        self._extraction_in_progress = True
+        self.text_processor.extract_selected_text()
 
     def _create_popup_window(self):
         """팝업 윈도우 생성 및 워밍업"""
@@ -321,10 +381,22 @@ class QuillApp(QApplication):
         if not text:
             logger.debug("No text selected, ignoring hotkey")
             self._quick_mode = False  # 플래그 리셋
+            self._pending_direct_prompt_key = ""
             return
 
-        logger.debug(f"Text extracted (length: {len(text)}), quick_mode={self._quick_mode}")
+        logger.debug(
+            f"Text extracted (length: {len(text)}), quick_mode={self._quick_mode}, "
+            f"direct_mode={bool(self._pending_direct_prompt_key)}"
+        )
         self.current_text = text
+
+        # Direct mode: run the specified prompt without opening the popup
+        if self._pending_direct_prompt_key:
+            prompt_key = self._pending_direct_prompt_key
+            self._pending_direct_prompt_key = ""
+            logger.debug(f"Direct mode: executing {prompt_key}")
+            self._on_action_requested(prompt_key, text, "")
+            return
 
         # 빠른 실행 모드: 팝업 없이 바로 AI 호출
         if self._quick_mode:
@@ -468,7 +540,8 @@ class QuillApp(QApplication):
             # 핫키 재시작
             hotkey = self.config_manager.get("hotkey.key", "<ctrl>+<space>")
             quick_hotkey = self.config_manager.get("hotkey.quick_key", "")
-            self.hotkey_manager.set_hotkeys(hotkey, quick_hotkey)
+            action_hotkeys = self._get_action_hotkeys_config()
+            self.hotkey_manager.set_hotkeys(hotkey, quick_hotkey, action_hotkeys)
 
             logger.info("Configuration reloaded successfully")
 

--- a/app/hotkey_manager.py
+++ b/app/hotkey_manager.py
@@ -6,7 +6,7 @@ pynput을 사용하여 Windows 전역 핫키를 감지합니다.
 
 import logging
 import time
-from typing import Optional
+from typing import Optional, Dict
 from PySide6.QtCore import QObject, Signal
 
 from pynput import keyboard
@@ -22,6 +22,7 @@ class HotkeyManager(QObject):
     # Signal: 핫키가 눌렸을 때 (x, y 마우스 위치)
     hotkey_pressed = Signal(int, int)
     quick_hotkey_pressed = Signal(int, int)  # 빠른 반복 핫키
+    action_hotkey_pressed = Signal(str, int, int)  # Direct action hotkey (prompt_key, x, y)
 
     def __init__(self):
         """HotkeyManager 초기화"""
@@ -30,6 +31,7 @@ class HotkeyManager(QObject):
         self.listener: Optional[keyboard.GlobalHotKeys] = None
         self.hotkey: str = "<ctrl>+<space>"  # 기본 핫키
         self.quick_hotkey: str = ""  # 빠른 반복 핫키 (빈 문자열이면 비활성화)
+        self.action_hotkeys: Dict[str, str] = {}  # Per-prompt direct action hotkeys
         self.is_active: bool = True
         self.mouse = MouseController()
 
@@ -39,7 +41,12 @@ class HotkeyManager(QObject):
 
         logger.debug("HotkeyManager initialized")
 
-    def start(self, hotkey: Optional[str] = None, quick_hotkey: Optional[str] = None):
+    def start(
+        self,
+        hotkey: Optional[str] = None,
+        quick_hotkey: Optional[str] = None,
+        action_hotkeys: Optional[Dict[str, str]] = None
+    ):
         """
         핫키 리스닝 시작
 
@@ -48,11 +55,15 @@ class HotkeyManager(QObject):
                    None이면 현재 핫키 사용
             quick_hotkey: 빠른 반복 핫키 문자열 (예: "<ctrl>+<alt>+<space>")
                    None이면 현재 설정 사용, 빈 문자열이면 비활성화
+            action_hotkeys: Per-prompt direct action hotkeys
+                    e.g., {"rewrite": "<ctrl>+<alt>+r"}
         """
         if hotkey:
             self.hotkey = hotkey
         if quick_hotkey is not None:
             self.quick_hotkey = quick_hotkey
+        if action_hotkeys is not None:
+            self.action_hotkeys = action_hotkeys.copy()
 
         # 이미 실행 중이면 중지
         if self.listener and self.listener.running:
@@ -65,13 +76,23 @@ class HotkeyManager(QObject):
                 hotkeys_dict[self.quick_hotkey] = self._on_quick_hotkey_activated
                 logger.info(f"Quick hotkey registered: {self.quick_hotkey}")
 
+            for prompt_key, action_hotkey in self.action_hotkeys.items():
+                if not action_hotkey:
+                    continue
+                hotkeys_dict[action_hotkey] = self._make_action_callback(prompt_key)
+                logger.info(f"Action hotkey registered: {prompt_key} -> {action_hotkey}")
+
             logger.info(f"Registering hotkeys: {list(hotkeys_dict.keys())}")
 
             # GlobalHotKeys 리스너 생성
             self.listener = keyboard.GlobalHotKeys(hotkeys_dict)
 
             self.listener.start()
-            logger.info(f"Hotkey listener started: main={self.hotkey}, quick={self.quick_hotkey or 'disabled'}")
+            enabled_action_count = sum(1 for key in self.action_hotkeys.values() if key)
+            logger.info(
+                f"Hotkey listener started: main={self.hotkey}, quick={self.quick_hotkey or 'disabled'}, "
+                f"actions={enabled_action_count}"
+            )
 
         except Exception as e:
             logger.error(f"Failed to start hotkey listener: {e}")
@@ -84,13 +105,19 @@ class HotkeyManager(QObject):
             self.listener = None
             logger.info("Hotkey listener stopped")
 
-    def set_hotkeys(self, hotkey: Optional[str] = None, quick_hotkey: Optional[str] = None):
+    def set_hotkeys(
+        self,
+        hotkey: Optional[str] = None,
+        quick_hotkey: Optional[str] = None,
+        action_hotkeys: Optional[Dict[str, str]] = None
+    ):
         """
         핫키 변경 (리스너 재시작)
 
         Args:
             hotkey: 새 메인 핫키 문자열
             quick_hotkey: 새 빠른 반복 핫키 문자열
+            action_hotkeys: New per-prompt direct action hotkeys
         """
         if hotkey:
             logger.info(f"Changing main hotkey: {self.hotkey} -> {hotkey}")
@@ -98,9 +125,16 @@ class HotkeyManager(QObject):
         if quick_hotkey is not None:
             logger.info(f"Changing quick hotkey: {self.quick_hotkey} -> {quick_hotkey or 'disabled'}")
             self.quick_hotkey = quick_hotkey
+        if action_hotkeys is not None:
+            self.action_hotkeys = action_hotkeys.copy()
+            logger.info(f"Changing action hotkeys: {self.action_hotkeys}")
 
         if self.is_active:
             self.start()
+
+    def _make_action_callback(self, prompt_key: str):
+        """Create a hotkey callback for a specific prompt key."""
+        return lambda: self._on_action_hotkey_activated(prompt_key)
 
     def pause(self):
         """핫키 감지 일시 중지"""
@@ -155,6 +189,19 @@ class HotkeyManager(QObject):
 
         except Exception as e:
             logger.error(f"Error in quick hotkey callback: {e}")
+
+    def _on_action_hotkey_activated(self, prompt_key: str):
+        """Callback when a direct action hotkey is pressed."""
+        if not self.is_active:
+            logger.debug("Action hotkey pressed but paused, ignoring")
+            return
+
+        try:
+            x, y = self.mouse.position
+            logger.debug(f"Action hotkey activated at position ({x}, {y}): {prompt_key}")
+            self.action_hotkey_pressed.emit(prompt_key, x, y)
+        except Exception as e:
+            logger.error(f"Error in action hotkey callback: {e}")
 
     def is_running(self) -> bool:
         """

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -29,6 +29,12 @@ class ConfigManager:
         "hotkey": {
             "key": "<ctrl>+<space>",
             "quick_key": "<ctrl>+<shift>+<space>",
+            "action_keys": {
+                "grammar_check": "<ctrl>+<shift>+<g>",
+                "rewrite": "<ctrl>+<shift>+<r>",
+                "summarize": "<ctrl>+<shift>+<s>",
+                "translate": "<ctrl>+<shift>+<t>"
+            },
             "enabled": True
         },
         "ui": {

--- a/ui/settings_window.py
+++ b/ui/settings_window.py
@@ -77,6 +77,19 @@ class HotkeyEdit(QLineEdit):
 class SettingsWindow(QDialog):
     """설정 창"""
 
+    ACTION_HOTKEY_LABELS = {
+        "grammar_check": "Grammar Check:",
+        "rewrite": "Rewrite:",
+        "summarize": "Summarize:",
+        "translate": "Translate:"
+    }
+    DEFAULT_ACTION_HOTKEYS = {
+        "grammar_check": "<ctrl>+<shift>+<g>",
+        "rewrite": "<ctrl>+<shift>+<r>",
+        "summarize": "<ctrl>+<shift>+<s>",
+        "translate": "<ctrl>+<shift>+<t>"
+    }
+
     # Signal: 설정 저장 완료
     settings_saved = Signal(dict)
 
@@ -95,6 +108,7 @@ class SettingsWindow(QDialog):
         self.config_manager = config_manager
         self.crypto_manager = crypto_manager
         self.prompt_manager = prompt_manager
+        self.input_action_hotkeys = {}
 
         self.setWindowTitle("Quill - Settings")
         self.setModal(True)
@@ -225,7 +239,8 @@ class SettingsWindow(QDialog):
         # 도움말
         help_label = QLabel(
             "Main Hotkey: Opens the prompt selection popup\n"
-            "Quick Repeat: Repeats last action without popup (leave empty to disable)\n\n"
+            "Quick Repeat: Repeats last action without popup (leave empty to disable)\n"
+            "Direct Action Hotkeys: Run a specific action immediately\n\n"
             "Format: <ctrl>+<space>, <ctrl>+<alt>+<space>, <alt>+q\n"
             "Note: Regular keys (a-z, 0-9) don't need angle brackets"
         )
@@ -235,6 +250,27 @@ class SettingsWindow(QDialog):
 
         hotkey_group.setLayout(hotkey_layout)
         layout.addWidget(hotkey_group)
+
+        # Direct action hotkey settings group
+        action_group = QGroupBox("Direct Action Hotkeys (Optional)")
+        action_layout = QFormLayout()
+        action_layout.setSpacing(12)
+
+        for prompt_key, label in self.ACTION_HOTKEY_LABELS.items():
+            hotkey_input = HotkeyEdit()
+            self.input_action_hotkeys[prompt_key] = hotkey_input
+            action_layout.addRow(label, hotkey_input)
+
+        action_help_label = QLabel(
+            "Select text and press a direct action hotkey to run without opening the popup.\n"
+            "Leave empty to disable any action."
+        )
+        action_help_label.setObjectName("subtitleLabel")
+        action_help_label.setWordWrap(True)
+        action_layout.addRow("", action_help_label)
+
+        action_group.setLayout(action_layout)
+        layout.addWidget(action_group)
 
         layout.addStretch()
 
@@ -533,6 +569,21 @@ class SettingsWindow(QDialog):
             quick_hotkey = self.config_manager.get("hotkey.quick_key", "")
             self.input_quick_hotkey.set_key_sequence(quick_hotkey)
 
+            action_hotkeys = self.config_manager.get(
+                "hotkey.action_keys",
+                self.DEFAULT_ACTION_HOTKEYS.copy()
+            )
+            if not isinstance(action_hotkeys, dict):
+                action_hotkeys = self.DEFAULT_ACTION_HOTKEYS.copy()
+
+            for prompt_key, hotkey_input in self.input_action_hotkeys.items():
+                hotkey_value = action_hotkeys.get(
+                    prompt_key,
+                    self.DEFAULT_ACTION_HOTKEYS.get(prompt_key, "")
+                )
+                if isinstance(hotkey_value, str):
+                    hotkey_input.set_key_sequence(hotkey_value)
+
             logger.debug("Current settings loaded")
 
         except Exception as e:
@@ -589,67 +640,71 @@ class SettingsWindow(QDialog):
                 self.config_manager.set_api_key(api_key)
 
             # 핫키 저장
-            hotkey = self.input_hotkey.get_key_sequence()
-            if hotkey:
-                # Validate hotkey has at least one modifier
-                if not any(mod in hotkey for mod in ['<ctrl>', '<shift>', '<alt>']):
+            critical_hotkeys = [
+                '<alt>+<f4>',  # Close window
+                '<ctrl>+<alt>+<delete>',  # Security screen
+                '<ctrl>+<shift>+<esc>',  # Task Manager
+            ]
+            used_hotkeys = {}
+
+            def validate_hotkey(field_name: str, hotkey_value: str) -> bool:
+                # Must include at least one modifier key
+                if not any(mod in hotkey_value for mod in ['<ctrl>', '<shift>', '<alt>']):
                     QMessageBox.warning(
                         self,
                         "Invalid Hotkey",
-                        "Hotkey must include at least one modifier key (Ctrl, Shift, or Alt)."
+                        f"{field_name} must include at least one modifier key (Ctrl, Shift, or Alt)."
                     )
-                    return
+                    return False
 
-                # Validate against critical system hotkeys only
-                critical_hotkeys = [
-                    '<alt>+<f4>',  # Close window
-                    '<ctrl>+<alt>+<delete>',  # Security screen
-                    '<ctrl>+<shift>+<esc>',  # Task Manager
-                ]
-
-                if hotkey.lower() in critical_hotkeys:
+                # Block reserved system hotkeys
+                if hotkey_value.lower() in critical_hotkeys:
                     QMessageBox.warning(
                         self,
                         "Reserved Hotkey",
-                        f"'{hotkey}' is a critical system hotkey and cannot be used.\n\n"
+                        f"'{hotkey_value}' is a critical system hotkey and cannot be used.\n\n"
                         "Please choose a different combination."
                     )
-                    return
+                    return False
 
+                # Prevent collisions with other configured hotkeys
+                existing_field = used_hotkeys.get(hotkey_value.lower())
+                if existing_field:
+                    QMessageBox.warning(
+                        self,
+                        "Duplicate Hotkey",
+                        f"{field_name} uses the same hotkey as {existing_field}.\n\n"
+                        "Each hotkey must be unique."
+                    )
+                    return False
+
+                used_hotkeys[hotkey_value.lower()] = field_name
+                return True
+
+            hotkey = self.input_hotkey.get_key_sequence()
+            if hotkey and not validate_hotkey("Main Hotkey", hotkey):
+                return
+            if hotkey:
                 self.config_manager.set("hotkey.key", hotkey)
 
             # 빠른 반복 핫키 저장
             quick_hotkey = self.input_quick_hotkey.get_key_sequence()
-            if quick_hotkey:
-                # Validate quick hotkey has at least one modifier
-                if not any(mod in quick_hotkey for mod in ['<ctrl>', '<shift>', '<alt>']):
-                    QMessageBox.warning(
-                        self,
-                        "Invalid Quick Hotkey",
-                        "Quick Repeat hotkey must include at least one modifier key (Ctrl, Shift, or Alt)."
-                    )
+            if quick_hotkey and not validate_hotkey("Quick Repeat", quick_hotkey):
+                return
+
+            # Save direct action hotkeys
+            action_hotkeys = {}
+            for prompt_key, label in self.ACTION_HOTKEY_LABELS.items():
+                action_hotkey = self.input_action_hotkeys[prompt_key].get_key_sequence()
+                action_name = label.rstrip(':')
+
+                if action_hotkey and not validate_hotkey(action_name, action_hotkey):
                     return
 
-                # Validate quick hotkey is different from main hotkey
-                if hotkey and quick_hotkey.lower() == hotkey.lower():
-                    QMessageBox.warning(
-                        self,
-                        "Invalid Quick Hotkey",
-                        "Quick Repeat hotkey must be different from Main Hotkey."
-                    )
-                    return
-
-                # Validate against critical system hotkeys
-                if quick_hotkey.lower() in critical_hotkeys:
-                    QMessageBox.warning(
-                        self,
-                        "Reserved Hotkey",
-                        f"'{quick_hotkey}' is a critical system hotkey and cannot be used.\n\n"
-                        "Please choose a different combination."
-                    )
-                    return
+                action_hotkeys[prompt_key] = action_hotkey
 
             self.config_manager.set("hotkey.quick_key", quick_hotkey)
+            self.config_manager.set("hotkey.action_keys", action_hotkeys)
 
             # 파일에 저장
             self.config_manager.save()


### PR DESCRIPTION
adds direct hotkeys for each built-in action so users can run Grammar, Rewrite, Summarize, and Translate immediately without opening the action picker first. Previously, the fast path depended on the “last used action” shortcut, which was less predictable if you switched tasks often; now each action has its own default shortcut (Ctrl+Shift+G/R/S/T), and all of them are configurable in Settings and persisted in config. The README was also updated to document the new shortcuts and expected behaviour.